### PR TITLE
[Fix][CD]: Add sudo before the docker commands 

### DIFF
--- a/.github/workflows/deploy_to_ec2.yml
+++ b/.github/workflows/deploy_to_ec2.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install SSH Key
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
 
@@ -22,8 +22,8 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no adamma2048@34.75.81.44 << EOF
           cd seprojects-cs673a2f24_team5
-          bash docker_auto_start.sh stop
+          sudo bash docker_auto_start.sh stop
           git switch main
           git pull
-          bash docker_auto_start.sh start
+          sudo bash docker_auto_start.sh start
           EOF


### PR DESCRIPTION
## Context

Fix the permission issue as running docker commands

## Changes

- Add `sudo` command before docker commands.

## Screenshot (if applicated)
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/6ae455cd-c19a-4595-a4ae-52bfc006d85c">

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
